### PR TITLE
Make logo placement customizable (param: `logo-placement`)

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -9,6 +9,7 @@
   author: none,
   affiliation: none,
   logo: none,
+  logo-placement: top + right,
   language: "de",
   show-outline: true,
   body,
@@ -36,6 +37,7 @@
     author,
     affiliation,
     logo,
+    logo-placement,
     heading-font,
     info-size,
   )

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,5 +1,6 @@
 
-#import "@preview/basic-report:0.1.1": *
+// #import "@preview/basic-report:0.1.1": *
+#import "../lib.typ": *
 
 #show: it => basic-report(
   doc-category: "Betriebsanleitung",
@@ -8,6 +9,7 @@
   affiliation: "MouseTec, Entenhausen",
   logo: image("assets/aerospace-engineering.png", width: 2cm),
   // <a href="https://www.flaticon.com/free-icons/aerospace" title="aerospace icons">Aerospace icons created by gravisio - Flaticon</a>
+  // logo-placement: top + center,
   language: "de",
   it
 )

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -6,6 +6,7 @@
   author,
   affiliation,
   logo,
+  logo-placement,
   heading-font,             // the heading-font is also used for all text on the titlepage
   info-size,                // used throughout the document for "info text"
 ) = {
@@ -22,7 +23,9 @@
   // - the page uses a grid of 1.5 cm units
 
   // ----- Logo ------------------------
-  place(top + right,        // `place` so that the remaining layout is independent of the size of the logo
+  place(
+    // `place` so that the remaining layout is independent of the size of the logo
+    logo-placement,
     logo,
   )
 


### PR DESCRIPTION
I have a logo which is supposed to be centered and I think others may also need this.

This change is backwards compatible because the default behavior is the same as before.