### PR TITLE
Allow custom datetime formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,6 @@ The template exports one function `basic-report` with the following named parame
 -  `compact-mode (boolean)`: If true, there is no TOC and no separate title page. All title information is displayed on the first text page (default is `false`)
 -  `heading-color`: The color of the title and all headings (default is `blue`)
 -  `heading-font`: The font used for the title and all headings (default is `"Ubuntu"`; recommended and tested alternatives are "Lato", "Fira Sans" or "Source Sans Pro")
+-  `datetime-fmt`: The datetime format used for the title page (default is `"[day].[month].[year]"`)
 
 Have a look at the example file [`main.typ`](https://github.com/roland-KA/basic-report-typst-template/blob/main/template/main.typ) whithin the [`template`](https://github.com/roland-KA/basic-report-typst-template/tree/main/template) directory on how to use the `basic-report`-function with these parameters.

--- a/lib.typ
+++ b/lib.typ
@@ -14,6 +14,7 @@
   compact-mode: false,
   heading-color: blue,
   heading-font: "Ubuntu", // recommended alternatives: "Fira Sans", "Lato", "Source Sans Pro"
+  datetime-fmt: "[day].[month].[year]",
   body,
 ) = {
 
@@ -49,6 +50,7 @@
       heading-font,
       heading-color,
       info-size,
+      datetime-fmt,
     )
   } 
 
@@ -215,6 +217,7 @@
       info-size,                
       body-size,
       label-size,
+      datetime-fmt,
     )
   }
 

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -89,7 +89,7 @@
         text(font: heading-font, size: label-size,
           author + "\n" + 
           affiliation + ", " + 
-          datetime.today().display("[day].[month].[year]")
+          datetime.today().display(datetime-fmt)
         )  
       ),
     )

--- a/titlepage.typ
+++ b/titlepage.typ
@@ -12,6 +12,7 @@
   heading-font,             // the heading-font is also used for all text on the titlepage
   heading-color,            // heading-color applies as well for the title
   info-size,                // used throughout the document for "info text"
+  datetime-fmt,
 ) = {
 
   // ----- Page-Setup ------------------------
@@ -50,7 +51,7 @@
     bottom + left,
     text(
       font: heading-font, weight: "regular", size: info-size, fill: black,
-      datetime.today().display("[day].[month].[year]") + str("\n") + 
+      datetime.today().display(datetime-fmt) + str("\n") + 
       author + str("\n") + 
       affiliation),
   )
@@ -70,6 +71,7 @@
   info-size,                // used throughout the document for "info text"
   body-size,
   label-size,
+  datetime-fmt,
 ) = {
   stack(
       v(1.5cm - 0.6cm),     // 3.6cm top-margin -0.6cm + 1.5cm = 4.5cm 


### PR DESCRIPTION
There are a lot of datetime formats to choose from. This will default to the format of the current template, but allow users to set their own format, such as:

`"[year].[month].[day]"` or `"[month].[day].[year]"`