### PR TITLE
Double-sided printing

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -12,6 +12,7 @@
   language: "de",
   show-outline: true,
   compact-mode: false,
+  double-sided: false,
   heading-color: blue,
   heading-font: "Ubuntu", // recommended alternatives: "Fira Sans", "Lato", "Source Sans Pro"
   datetime-fmt: "[day].[month].[year]",
@@ -75,16 +76,21 @@
   // Horizontal 1.5cm-grid = 14u: 3u left margin, 9u text, 2u right margin
   //     Idea: one-sided document; if printed on paper, the pages are often bound or stapled
   //     on the left side; so more space needed on the left. On-screen it doesn't matter.
+  //     For double-sided document the margins alternate, so the added space for binding/stapling will line up front and back.
   // Vertical 1.5cm-grid ≈ 20u: 2u top margin, 14u text, 2u botttom margin
   //     header with height ≈ 0.6cm is visually part of text block --> top margin = 3cm + 0.6cm
   set page(               // standard page with header
     paper: "a4",
-    margin: (top: 3.6cm, left: 4.5cm, right: 3cm, bottom: 3cm),
-    // the header shows the main chapter heading on the left and the page number on the right
+    margin: if double-sided {
+      (top: 3.6cm, inside: 4.5cm, outside: 3cm, bottom: 3cm)
+    } else {
+      (top: 3.6cm, left: 4.5cm, right: 3cm, bottom: 3cm)
+    },
+    // in one-sided mode, the header shows the main chapter heading on the left and the page number on the right; in double-sided it alternates
     header: context {
       if compact-mode and (counter(page).get().first() == 1) {
         none
-      } else {
+      } else if double-sided and calc.even(counter(page).get().first()) {
         grid(
           columns: (1fr, 1fr),
           align: (left, right),
@@ -100,6 +106,24 @@
               }
             }
           ),
+          grid.cell(colspan: 2, line(length: 100%, stroke: 0.5pt)),
+        )
+      } else {
+        grid(
+          columns: (1fr, 1fr),
+          align: (left, right),
+          row-gutter: 0.5em,
+          text(font: heading-font, size: label-size, 
+            number-type: "lining",
+            context {if in-outline.get() {
+                counter(page).display("i")      // roman page numbers for the TOC
+              } else {
+                counter(page).display("1")      // arabic page numbers for the rest of the document
+              }
+            }
+          ),
+          text(font: heading-font, size: label-size,
+            context {hydra(1, use-last: false, skip-starting: false)},),
           grid.cell(colspan: 2, line(length: 100%, stroke: 0.5pt)),
         )
       }

--- a/template/main.typ
+++ b/template/main.typ
@@ -10,6 +10,7 @@
   // <a href="https://www.flaticon.com/free-icons/aerospace" title="aerospace icons">Aerospace icons created by gravisio - Flaticon</a>
   language: "de",
   compact-mode: true,
+  double-sided: false,
   it
 )
 


### PR DESCRIPTION
This pull request adds an optional parameter `double-sided`, which alternates header orientations and left/right margins, so that the document will look good when printed double-sided instead of one-sided. The larger margins for stapling/binding will line up on the front and back of the paper.

`double-sided` will default to `false` when not set in the preamble of `main.typ`.

I recommend users add an empty page after the title page if using double-sided, but did not hardcode this, to leave the decision up to the user.